### PR TITLE
feat: Create seeder for appointments

### DIFF
--- a/dental-clinic-pms/database/factories/AppointmentFactory.php
+++ b/dental-clinic-pms/database/factories/AppointmentFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Appointment;
+use App\Models\Patient;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Carbon\Carbon;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Appointment>
+ */
+class AppointmentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $patientIds = Patient::pluck('id')->toArray();
+        $dentistIds = User::where('role', 'dentist')->pluck('id')->toArray();
+
+        $appointmentDatetime = $this->faker->dateTimeBetween('-3 months', '+3 months');
+        $status = $this->getRandomStatus($appointmentDatetime);
+
+        return [
+            'patient_id' => $this->faker->randomElement($patientIds),
+            'dentist_id' => $this->faker->randomElement($dentistIds),
+            'appointment_datetime' => $appointmentDatetime,
+            'duration_minutes' => $this->faker->randomElement([15, 30, 45, 60]),
+            'appointment_type' => $this->faker->randomElement(['Consultation', 'Cleaning', 'Extraction', 'Filling', 'Check-up']),
+            'status' => $status,
+            'reason_for_visit' => $this->faker->sentence,
+            'appointment_notes' => $this->faker->optional()->paragraph,
+            'cancellation_reason' => $status === 'cancelled' ? $this->faker->sentence : null,
+        ];
+    }
+
+    /**
+     * Get a realistic status based on the appointment date.
+     */
+    private function getRandomStatus(Carbon $datetime): string
+    {
+        if ($datetime->isFuture()) {
+            return $this->faker->randomElement([
+                Appointment::STATUS_SCHEDULED,
+                Appointment::STATUS_CONFIRMED,
+                Appointment::STATUS_CANCELLED
+            ]);
+        } else {
+            return $this->faker->randomElement([
+                Appointment::STATUS_COMPLETED,
+                Appointment::STATUS_CANCELLED,
+                Appointment::STATUS_NO_SHOW
+            ]);
+        }
+    }
+}

--- a/dental-clinic-pms/database/seeders/AppointmentSeeder.php
+++ b/dental-clinic-pms/database/seeders/AppointmentSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Appointment;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class AppointmentSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Appointment::factory()->count(200)->create();
+    }
+}

--- a/dental-clinic-pms/database/seeders/DatabaseSeeder.php
+++ b/dental-clinic-pms/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,7 @@ class DatabaseSeeder extends Seeder
             UserSeeder::class,
             PatientSeeder::class,
             ProcedureSeeder::class,
+            AppointmentSeeder::class,
             TreatmentPlanSeeder::class,
             TreatmentRecordSeeder::class,
         ]);


### PR DESCRIPTION
This commit adds a database seeder for appointments.

- An `AppointmentFactory` is created to generate realistic sample data for appointments, including randomizing patients, dentists, dates, and statuses.
- An `AppointmentSeeder` is added to leverage the factory to populate the database with 200 sample appointments.
- The main `DatabaseSeeder` is updated to include the `AppointmentSeeder` in the seeding process.