### PR TITLE
fix: Handle nullable fields in AppointmentController

### DIFF
--- a/dental-clinic-pms/app/Http/Controllers/AppointmentController.php
+++ b/dental-clinic-pms/app/Http/Controllers/AppointmentController.php
@@ -93,8 +93,8 @@ class AppointmentController extends Controller
             'appointment_datetime' => $datetime,
             'duration_minutes' => $validated['duration_minutes'],
             'appointment_type' => $validated['appointment_type'],
-            'reason_for_visit' => $validated['reason_for_visit'],
-            'appointment_notes' => $validated['appointment_notes'],
+            'reason_for_visit' => $validated['reason_for_visit'] ?? null,
+            'appointment_notes' => $validated['appointment_notes'] ?? null,
             'status' => Appointment::STATUS_SCHEDULED,
         ]);
 
@@ -171,9 +171,9 @@ class AppointmentController extends Controller
             'duration_minutes' => $validated['duration_minutes'],
             'appointment_type' => $validated['appointment_type'],
             'status' => $validated['status'],
-            'reason_for_visit' => $validated['reason_for_visit'],
-            'appointment_notes' => $validated['appointment_notes'],
-            'cancellation_reason' => $validated['cancellation_reason'],
+            'reason_for_visit' => $validated['reason_for_visit'] ?? null,
+            'appointment_notes' => $validated['appointment_notes'] ?? null,
+            'cancellation_reason' => $validated['cancellation_reason'] ?? null,
         ]);
 
         $appointment->addModificationHistory('Updated by receptionist/admin');


### PR DESCRIPTION
This commit fixes a potential bug in the `AppointmentController` where optional fields could cause an error if they were not present in the request.

- The `store` and `update` methods have been updated to use the null coalescing operator (`?? null`) for optional fields like `reason_for_visit` and `appointment_notes`.
- This ensures that a `null` value is explicitly passed to the `create` and `update` methods, preventing potential "Undefined array key" errors and database constraint violations if the database schema is not perfectly aligned with the application's expectations.