### PR TITLE
Make cards resizable and draggable

### DIFF
--- a/dental-clinic-pms/resources/views/dashboard-v3.blade.php
+++ b/dental-clinic-pms/resources/views/dashboard-v3.blade.php
@@ -27,63 +27,65 @@
 
 @push('scripts')
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-    const container = document.getElementById('dashboard-container');
-    const cards = document.querySelectorAll('.card');
-    
-    cards.forEach(card => {
-        let isDragging = false;
-        let startX, startY, startLeft, startTop;
-        
-        // Mouse down event
-        card.addEventListener('mousedown', function(e) {
-            console.log('Mouse down on card');
-            isDragging = true;
-            startX = e.clientX;
-            startY = e.clientY;
-            startLeft = parseInt(card.style.left) || 0;
-            startTop = parseInt(card.style.top) || 0;
-            
-            card.style.zIndex = '1000';
-            e.preventDefault();
-            e.stopPropagation();
+(function initDragAndResize() {
+    function init() {
+        const container = document.getElementById('dashboard-container');
+        const cards = document.querySelectorAll('.card');
+
+        cards.forEach(card => {
+            let isDragging = false;
+            let startX, startY, startLeft, startTop;
+
+            card.addEventListener('mousedown', function(e) {
+                isDragging = true;
+                startX = e.clientX;
+                startY = e.clientY;
+                startLeft = parseInt(card.style.left) || 0;
+                startTop = parseInt(card.style.top) || 0;
+
+                card.style.zIndex = '1000';
+                e.preventDefault();
+                e.stopPropagation();
+            });
+
+            document.addEventListener('mousemove', function(e) {
+                if (!isDragging) return;
+
+                const deltaX = e.clientX - startX;
+                const deltaY = e.clientY - startY;
+
+                let newLeft = startLeft + deltaX;
+                let newTop = startTop + deltaY;
+
+                const containerRect = container.getBoundingClientRect();
+                const cardWidth = card.offsetWidth;
+                const cardHeight = card.offsetHeight;
+
+                const padding = 20;
+                const maxLeft = containerRect.width - cardWidth - padding;
+                const maxTop = containerRect.height - cardHeight - padding;
+
+                newLeft = Math.max(padding, Math.min(newLeft, maxLeft));
+                newTop = Math.max(padding, Math.min(newTop, maxTop));
+
+                card.style.left = newLeft + 'px';
+                card.style.top = newTop + 'px';
+            });
+
+            document.addEventListener('mouseup', function() {
+                if (isDragging) {
+                    isDragging = false;
+                    card.style.zIndex = '10';
+                }
+            });
         });
-        
-        // Mouse move event
-        document.addEventListener('mousemove', function(e) {
-            if (!isDragging) return;
-            
-            const deltaX = e.clientX - startX;
-            const deltaY = e.clientY - startY;
-            
-            let newLeft = startLeft + deltaX;
-            let newTop = startTop + deltaY;
-            
-            // Get container bounds
-            const containerRect = container.getBoundingClientRect();
-            const cardWidth = card.offsetWidth;
-            const cardHeight = card.offsetHeight;
-            
-            // Constrain to container
-            const maxLeft = containerRect.width - cardWidth - 20;
-            const maxTop = containerRect.height - cardHeight - 20;
-            
-            newLeft = Math.max(20, Math.min(newLeft, maxLeft));
-            newTop = Math.max(20, Math.min(newTop, maxTop));
-            
-            card.style.left = newLeft + 'px';
-            card.style.top = newTop + 'px';
-        });
-        
-        // Mouse up event
-        document.addEventListener('mouseup', function() {
-            if (isDragging) {
-                console.log('Mouse up - stopping drag');
-                isDragging = false;
-                card.style.zIndex = '10';
-            }
-        });
-    });
-});
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();
 </script>
 @endpush

--- a/dental-clinic-pms/resources/views/dashboard.blade.php
+++ b/dental-clinic-pms/resources/views/dashboard.blade.php
@@ -16,7 +16,7 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="gridstack">
+            <div class="grid-stack">
                 @foreach ($widgets as $widget)
                     <div class="grid-stack-item" gs-x="{{ $widget['layout']['x'] }}" gs-y="{{ $widget['layout']['y'] }}" gs-w="{{ $widget['layout']['w'] }}" gs-h="{{ $widget['layout']['h'] }}" gs-id="{{ $widget['key'] }}">
                         <div class="grid-stack-item-content">
@@ -37,7 +37,7 @@
                 float: true,
                 cellHeight: '8rem',
                 minRow: 1,
-            });
+            }, '.grid-stack');
 
             const saveLayout = () => {
                 const serializedData = grid.save();


### PR DESCRIPTION
Enable dashboard card drag and resize by correcting the GridStack container class and ensuring reliable custom drag script initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-f991d0a1-c548-4970-9a89-661f6121d005">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f991d0a1-c548-4970-9a89-661f6121d005">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

