### PR TITLE
Fix appointment statistic widget display

### DIFF
--- a/dental-clinic-pms/resources/views/components/widgets/appointment-statistics.blade.php
+++ b/dental-clinic-pms/resources/views/components/widgets/appointment-statistics.blade.php
@@ -1,36 +1,69 @@
 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg h-full">
     <div class="p-6">
         <h3 class="text-lg font-semibold mb-4">Appointment Statistics</h3>
-        <canvas id="appointment-chart"></canvas>
+        <div class="relative h-64">
+            <canvas id="appointment-chart"></canvas>
+            <div id="appointment-chart-empty" class="absolute inset-0 flex items-center justify-center text-gray-500 hidden">
+                No appointment data to display
+            </div>
+        </div>
     </div>
 </div>
 
 @push('scripts')
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        const ctx = document.getElementById('appointment-chart').getContext('2d');
-        new Chart(ctx, {
-            type: 'doughnut',
-            data: {
-                labels: @json(array_keys(($data['appointments_by_status'] ?? collect())->toArray())),
-                datasets: [{
-                    label: 'Appointments',
-                    data: @json(array_values(($data['appointments_by_status'] ?? collect())->toArray())),
-                    backgroundColor: [
-                        'rgba(54, 162, 235, 0.8)',
-                        'rgba(255, 206, 86, 0.8)',
-                        'rgba(75, 192, 192, 0.8)',
-                        'rgba(153, 102, 255, 0.8)',
-                        'rgba(255, 159, 64, 0.8)'
-                    ],
-                }]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
+    (function initAppointmentChart() {
+        const render = () => {
+            const canvas = document.getElementById('appointment-chart');
+            if (!canvas) return;
+            const ctx = canvas.getContext('2d');
+
+            const labels = @json(array_keys(($data['appointments_by_status'] ?? collect())->toArray()));
+            const values = @json(array_values(($data['appointments_by_status'] ?? collect())->toArray()));
+
+            const isEmpty = !values || values.length === 0 || values.every(v => Number(v) === 0);
+            const emptyEl = document.getElementById('appointment-chart-empty');
+
+            if (isEmpty) {
+                if (emptyEl) emptyEl.classList.remove('hidden');
+                if (ctx) {
+                    // clear any previous chart drawing if exists
+                    ctx.clearRect(0, 0, canvas.width, canvas.height);
+                }
+                return;
+            } else if (emptyEl) {
+                emptyEl.classList.add('hidden');
             }
-        });
-    });
+
+            new Chart(ctx, {
+                type: 'doughnut',
+                data: {
+                    labels: labels,
+                    datasets: [{
+                        label: 'Appointments',
+                        data: values,
+                        backgroundColor: [
+                            'rgba(54, 162, 235, 0.8)',
+                            'rgba(255, 206, 86, 0.8)',
+                            'rgba(75, 192, 192, 0.8)',
+                            'rgba(153, 102, 255, 0.8)',
+                            'rgba(255, 159, 64, 0.8)'
+                        ],
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                }
+            });
+        };
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', render);
+        } else {
+            render();
+        }
+    })();
 </script>
 @endpush


### PR DESCRIPTION
Fixes the appointment statistics widget to display correctly and show a fallback message when no data is available.

The widget was not rendering because the script might not have run if `DOMContentLoaded` had already fired, and it didn't handle cases where there was no appointment data to display. This PR ensures the script initializes reliably and provides a clear "No data" message.

---
<a href="https://cursor.com/background-agent?bcId=bc-e842c837-e2cf-40c6-b337-e10a71106fa8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e842c837-e2cf-40c6-b337-e10a71106fa8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

